### PR TITLE
Adding support for Oklab & Oklch color models

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Added support for OkLab & Oklch color models
+
 # 0.2.0
 
 * Switch to using types from [Gg](http://erratique.ch/software/gg)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## color: converts between different color formats
 
 Library that converts between different color formats. Right now it deals with
-HSL, HSLA, RGB and RGBA formats.
+HSL, HSLA, RGB, RGBA, OkLab and Oklch formats.
 
 The goal for this library is to provide easy handling of colors on the web, when working
 with `js_of_ocaml`.

--- a/color.opam
+++ b/color.opam
@@ -1,7 +1,7 @@
 opam-version: "2.0"
 name: "color"
 maintainer: "anuragsoni.13@gmail.com"
-authors: ["Anurag Soni"]
+authors: ["Anurag Soni" "Ambre Austen Suhamy"]
 homepage: "https://github.com/anuragsoni/color"
 dev-repo: "git+https://github.com/anuragsoni/color.git"
 bug-reports: "https://github.com/anuragsoni/color/issues"

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -68,7 +68,7 @@ let of_oklab ?(alpha = 1.0) l a b =
   let r = (4.0767416621 *. l') -. (3.3077115913 *. m) +. (0.2309699292 *. s) in
   let g = (-1.2684380046 *. l') +. (2.6097574011 *. m) -. (0.3413193965 *. s) in
   let b = (-0.0041960863 *. l') -. (0.7034186147 *. m) +. (1.7076147010 *. s) in
-  Gg.Color.v_srgb ~a:alpha r g b |> Gg.Color.clamp
+  Gg.Color.v r g b alpha |> Gg.Color.clamp
 
 let of_oklch ?(alpha = 1.0) l c h =
   let h = deg_to_rad h in
@@ -132,18 +132,14 @@ let to_hsla t =
 
 let to_oklab t : Oklab.t =
   (* From https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab *)
-  let open Gg.Color in
-  let t = to_srgb t in
+  let r, g, b, alpha =
+    let open Gg.Color in
+    (r t, g t, b t, a t)
+  in
 
-  let l =
-    (0.4122214708 *. r t) +. (0.5363325363 *. g t) +. (0.0514459929 *. b t)
-  in
-  let m =
-    (0.2119034982 *. r t) +. (0.6806995451 *. g t) +. (0.1073969566 *. b t)
-  in
-  let s =
-    (0.0883024619 *. r t) +. (0.2817188376 *. g t) +. (0.6299787005 *. b t)
-  in
+  let l = (0.4122214708 *. r) +. (0.5363325363 *. g) +. (0.0514459929 *. b) in
+  let m = (0.2119034982 *. r) +. (0.6806995451 *. g) +. (0.1073969566 *. b) in
+  let s = (0.0883024619 *. r) +. (0.2817188376 *. g) +. (0.6299787005 *. b) in
 
   let l = Float.cbrt l in
   let m = Float.cbrt m in
@@ -153,7 +149,7 @@ let to_oklab t : Oklab.t =
     l = (0.2104542553 *. l) +. (0.7936177850 *. m) -. (0.0040720468 *. s);
     a = (1.9779984951 *. l) -. (2.4285922050 *. m) +. (0.4505937099 *. s);
     b = (0.0259040371 *. l) +. (0.7827717662 *. m) -. (0.8086757660 *. s);
-    alpha = a t;
+    alpha;
   }
 
 let to_oklch t : Oklch.t =
@@ -191,13 +187,13 @@ let to_css_rgba color =
 
 let to_css_oklab t =
   let ok = to_oklab t in
-  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %f" f in
-  Printf.sprintf "oklab(%f %f %f%a)" ok.l ok.a ok.b pp_alpha ok.alpha
+  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %.2f" f in
+  Printf.sprintf "oklab(%.2f %.2f %.2f%a)" ok.l ok.a ok.b pp_alpha ok.alpha
 
 let to_css_oklch t =
   let ok = to_oklch t in
-  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %f" f in
-  Printf.sprintf "oklch(%f %f %fdeg%a)" ok.l ok.c ok.h pp_alpha ok.alpha
+  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %.2f" f in
+  Printf.sprintf "oklch(%.2f %.2f %.2fdeg%a)" ok.l ok.c ok.h pp_alpha ok.alpha
 
 let black = Gg.Color.black
 

--- a/lib/color.ml
+++ b/lib/color.ml
@@ -2,6 +2,9 @@ let round x = int_of_float @@ Gg.Float.round x
 
 let positive_float x y = mod_float (mod_float x y +. y) y
 
+let deg_to_rad d = d *. Float.pi /. 180.
+let rad_to_deg r = r *. 180. /. Float.pi
+
 type t = Gg.color
 
 module Hsla = struct
@@ -14,6 +17,14 @@ end
 
 module Rgba = struct
   type t = {r: int; g: int; b: int; a: float}
+end
+
+module Oklab = struct
+  type t = { l : float; a : float; b : float; alpha : float }
+end
+
+module Oklch = struct
+  type t = { l : float; c : float; h : float; alpha : float }
 end
 
 let of_rgba r g b a = Gg.Color.v_srgbi ~a r g b |> Gg.Color.clamp
@@ -43,6 +54,27 @@ let of_hsla h s l a =
   else make 0. 0. 0.
 
 let of_hsl h s l = of_hsla h s l 1.
+
+let of_oklab ?(alpha = 1.0) l a b =
+  (* From https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab *)
+  let l' = l +. (0.3963377774 *. a) +. (0.2158037573 *. b) in
+  let m = l -. (0.1055613458 *. a) -. (0.0638541728 *. b) in
+  let s = l -. (0.0894841775 *. a) -. (1.2914855480 *. b) in
+
+  let l' = l' *. l' *. l' in
+  let m = m *. m *. m in
+  let s = s *. s *. s in
+
+  let r = (4.0767416621 *. l') -. (3.3077115913 *. m) +. (0.2309699292 *. s) in
+  let g = (-1.2684380046 *. l') +. (2.6097574011 *. m) -. (0.3413193965 *. s) in
+  let b = (-0.0041960863 *. l') -. (0.7034186147 *. m) +. (1.7076147010 *. s) in
+  Gg.Color.v_srgb ~a:alpha r g b |> Gg.Color.clamp
+
+let of_oklch ?(alpha = 1.0) l c h =
+  let h = deg_to_rad h in
+  let a = c *. cos h in
+  let b = c *. sin h in
+  of_oklab ~alpha l a b
 
 let of_hexstring s =
   if String.length s = 4 || String.length s = 7 then
@@ -98,6 +130,41 @@ let to_hsla t =
   in
   {Hsla.h= hue; s= saturation; l= lightness; a= alpha}
 
+let to_oklab t : Oklab.t =
+  (* From https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab *)
+  let open Gg.Color in
+  let t = to_srgb t in
+
+  let l =
+    (0.4122214708 *. r t) +. (0.5363325363 *. g t) +. (0.0514459929 *. b t)
+  in
+  let m =
+    (0.2119034982 *. r t) +. (0.6806995451 *. g t) +. (0.1073969566 *. b t)
+  in
+  let s =
+    (0.0883024619 *. r t) +. (0.2817188376 *. g t) +. (0.6299787005 *. b t)
+  in
+
+  let l = Float.cbrt l in
+  let m = Float.cbrt m in
+  let s = Float.cbrt s in
+
+  {
+    l = (0.2104542553 *. l) +. (0.7936177850 *. m) -. (0.0040720468 *. s);
+    a = (1.9779984951 *. l) -. (2.4285922050 *. m) +. (0.4505937099 *. s);
+    b = (0.0259040371 *. l) +. (0.7827717662 *. m) -. (0.8086757660 *. s);
+    alpha = a t;
+  }
+
+let to_oklch t : Oklch.t =
+  let ok = to_oklab t in
+  {
+    l = ok.l;
+    c = sqrt ((ok.a ** 2.0) +. (ok.b ** 2.0));
+    h = rad_to_deg (Float.atan2 ok.b ok.a);
+    alpha = ok.alpha;
+  }
+
 let to_hexstring color =
   let c = to_rgba color in
   let to_hex n =
@@ -121,6 +188,16 @@ let to_css_rgba color =
     Printf.sprintf "rgb(%d, %d, %d)" color'.r color'.g color'.b
   else
     Printf.sprintf "rgba(%d, %d, %d, %.2f)" color'.r color'.g color'.b color'.a
+
+let to_css_oklab t =
+  let ok = to_oklab t in
+  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %f" f in
+  Printf.sprintf "oklab(%f %f %f%a)" ok.l ok.a ok.b pp_alpha ok.alpha
+
+let to_css_oklch t =
+  let ok = to_oklch t in
+  let pp_alpha () = function 1.0 -> "" | f -> Printf.sprintf " / %f" f in
+  Printf.sprintf "oklch(%f %f %fdeg%a)" ok.l ok.c ok.h pp_alpha ok.alpha
 
 let black = Gg.Color.black
 

--- a/lib/color.mli
+++ b/lib/color.mli
@@ -15,6 +15,14 @@ module Rgba : sig
   type t = {r: int; g: int; b: int; a: float}
 end
 
+module Oklab : sig
+  type t = { l : float; a : float; b : float; alpha : float }
+end
+
+module Oklch : sig
+  type t = { l : float; c : float; h : float; alpha : float }
+end
+
 val of_rgba : int -> int -> int -> float -> t
 (** Creates a [color] from integer RGB values between 0 and 255
     and a floating point alpha value between 0.0 and 1.0.
@@ -39,6 +47,19 @@ val of_hsl : float -> float -> float -> t
     degrees, a float value between 0.0 and 360.0. Saturation and Lightness are float
     values between 0.0 and 1.0 *)
 
+val of_oklab : ?alpha:float -> float -> float -> float -> t
+(** Creates a [color] from LAB (and optional alpha).
+    l is lightness, between 0.0 and 1.0
+    a and b are floats values (theoretically unbounded but in practice do not exceed ~±0.5)
+    alpha is transparency, between 0.0 and 1.0 *)
+
+val of_oklch : ?alpha:float -> float -> float -> float -> t
+(** Creates a [color] from LCH (and optional alpha).
+    l is lightness, between 0.0 and 1.0
+    c is chroma, minimum is 0.0 and practical maximum value is ~0.5
+    h is hue in degrees, a float value between 0.0 and 360.0
+    alpha is transparency, between 0.0 and 1.0 *)
+
 val of_hexstring : string -> t option
 (** Parse a hexadecimal color code. Handles short format like [#rgb] or
     long format [#rrggbb]. Short format [#abc] corresponds to long format
@@ -56,6 +77,19 @@ val to_rgba : t -> Rgba.t
     integers in the range of 0 to 255. The alpha channel is a float between
     0.0 and 1.0 *)
 
+val to_oklab : t -> Oklab.t
+(** Converts a [color] to its Oklab value.
+    l is lightness, between 0.0 and 1.0
+    a and b are floats values (theoretically unbounded but in practice do not exceed ~±0.5)
+    alpha is transparency, between 0.0 and 1.0 *)
+
+val to_oklch : t -> Oklch.t
+(** Converts a [color] to its Oklch value.
+    l is lightness, between 0.0 and 1.0
+    c is chroma, minimum is 0.0 and practical maximum value is ~0.5
+    h is hue in degrees, a float value between 0.0 and 360.0
+    alpha is transparency, between 0.0 and 1.0 *)
+
 val to_hexstring : t -> string
 (** Converts a color to its hexadecimal representation. The alpha channel
     is not represented. *)
@@ -65,6 +99,12 @@ val to_css_hsla : t -> string
 
 val to_css_rgba : t -> string
 (** CSS representation of the color in [rgb(..)] or [rgba(..)] form. *)
+
+val to_css_oklab : t -> string
+(** CSS representation of the color in [oklab(..)] form. *)
+
+val to_css_oklch : t -> string
+(** CSS representation of the color in [oklch(..)] form. *)
 
 val black : t
 (** Pure black *)

--- a/test/color_conversion.ml
+++ b/test/color_conversion.ml
@@ -1,3 +1,27 @@
+module TestColor = struct
+  type t = Color.t
+
+  let pp fmt t =
+    let f c = c t *. 255. |> Float.round |> int_of_float in
+    let r, g, b =
+      let open Gg.Color in
+      (f r, f g, f b)
+    in
+    Format.fprintf fmt "#%02X%02X%02X" r g b
+
+  let equal t1 t2 =
+    (* epsilon chosen arbitrarily to pass tests *)
+    let epsilon = 1e-2 in
+    let cmp1 x y = epsilon > abs_float (x -. y) in
+    let cmp3 (r1, r2) (g1, g2) (b1, b2) =
+      cmp1 r1 r2 && cmp1 g1 g2 && cmp1 b1 b2
+    in
+    let open Gg.Color in
+    cmp3 (r t1, r t2) (g t1, g t2) (b t1, b t2)
+
+  let col_test = Alcotest.testable pp equal
+end
+
 let test_hsl_to_rgba () =
   let open Color in
   let colors =
@@ -50,7 +74,37 @@ let test_hexstring_to_color () =
     "Can create color from hexstring" true
     (List.for_all (fun x -> check x) colors_rgba_hex)
 
+let oklch_rgb_values =
+  [
+    (* Black *)
+    ((0.0, 0.0, 0.0), (0, 0, 0));
+    (* White *)
+    ((1.0, 0.0, 0.0), (255, 255, 255));
+    (* Pastel pink *)
+    ((0.7, 0.197, 348.35), (242, 97, 179));
+    (* Pastel orange *)
+    ((0.7118, 0.154, 45.53), (239, 127, 71));
+    (* Plant green *)
+    ((0.5471, 0.157, 145.06), (30, 135, 46));
+    (* Salmon *)
+    ((0.68, 0.138, 45.53), (221, 122, 74));
+    (* Egg yellow *)
+    ((0.84, 0.123, 80.47), (244, 194, 103));
+  ]
+
+let test_oklch_roundtrip () =
+  List.iter
+    (fun ((l, c, h), (r, g, b)) ->
+      let ok = Color.of_oklch l c h in
+      let rgb = Color.of_rgb r g b in
+      Alcotest.check TestColor.col_test
+        "Can convert from oklch & rgb to Color.t" rgb ok)
+    oklch_rgb_values
+
 let tests =
-  [ ("Hsl to RGBA'", `Quick, test_hsl_to_rgba)
-  ; ("Color to hexstring", `Quick, test_color_to_hexstring)
-  ; ("Hexstring to color", `Quick, test_hexstring_to_color) ]
+  [
+    ("Hsl to RGBA'", `Quick, test_hsl_to_rgba);
+    ("Color to hexstring", `Quick, test_color_to_hexstring);
+    ("Hexstring to color", `Quick, test_hexstring_to_color);
+    ("Oklch roundtrip", `Quick, test_oklch_roundtrip);
+  ]


### PR DESCRIPTION
A presentation of the oklab model can be found [here.](https://bottosson.github.io/posts/oklab/)
Please note that the added `to_css_ok[lab|lch]` functions will only work on select browsers, see the [mozilla compatibility page](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/oklch#browser_compatibility) for exact details.